### PR TITLE
fix(relay-v1): state that both A and B are in session mode (fixes #802)

### DIFF
--- a/specs/relay-v1.rst
+++ b/specs/relay-v1.rst
@@ -137,8 +137,11 @@ relayed between the two devices in the session directly.
 Example Exchange
 ^^^^^^^^^^^^^^^^
 
-Client A - Permanent protocol mode
-Client B - Temporary protocol mode
+Client A is the first to join the session.
+
+Client B is the second to join the session.
+
+Both are in session mode.
 
 ===  =======================  ====================== =====================
  #         Client (A)                 Relay                Client (B)


### PR DESCRIPTION
Permanent protocol and temporary protocol submodes don't exist in session mode.